### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ static const _heightPercentages = [
 
 WaveWidget(
     config: CustomConfig(
-        colors: colors,
+        colors: _colors,
         durations: _durations,
         heightPercentages: _heightPercentages,
     ),


### PR DESCRIPTION
I think `colors: colors` is a mistake for `colors: _colors` in [README.md.](https://github.com/glorylab/wave#getting-started)

```dart
WaveWidget(
    config: CustomConfig(
        colors: colors,
        durations: _durations,
```


Closing issues

closes https://github.com/glorylab/wave/issues/48
