### PR TITLE
Update Wrangler action to Node 24 runtime

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Deploy to Cloudflare Workers
         if: github.event_name != 'pull_request'
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/docs/cloudflare-workers.md
+++ b/docs/cloudflare-workers.md
@@ -27,7 +27,7 @@ The workflow in `.github/workflows/deploy-workers.yml` does the following:
 3. Runs `flutter pub get` at the package root.
 4. Runs `flutter pub get` in `example/`.
 5. Builds the demo with `flutter build web --release`.
-6. Runs `wrangler deploy` through `cloudflare/wrangler-action@v3`.
+6. Runs `wrangler deploy` through `cloudflare/wrangler-action@v4`.
 
 Pull requests build the Flutter web output but do not deploy. Pushes to `master` and manual `workflow_dispatch` runs deploy to the Worker named `wave`.
 


### PR DESCRIPTION
## Summary
- Update cloudflare/wrangler-action from v3 to v4 to remove the GitHub Actions Node.js 20 deprecation warning.
- Keep Wrangler itself pinned to v4 in the workflow.
- Update the deployment docs to match the workflow.

## Validation
- git diff --check
- Verified cloudflare/wrangler-action@v4.0.0 declares runs.using: node24 while v3 declares node20.