### PR TITLE
Prepare 0.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.2.3-dev.1
+## 0.2.3
 
 * Add runtime validation for custom gradient and layer configuration.
 * Add default rendering support for `SingleConfig` and `RandomConfig`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wave
 description: Widget for displaying waves with custom color, duration, floating and blur effects.
-version: 0.2.3-dev.1
+version: 0.2.3
 homepage: https://github.com/glorylab/wave
 
 environment:


### PR DESCRIPTION
Summary:
- Promote the package version from 0.2.3-dev.1 to 0.2.3.
- Update the CHANGELOG heading for the stable 0.2.3 release.

Validation:
- fvm flutter analyze
- fvm flutter test
- fvm flutter pub publish --dry-run (0 warnings)

Release note:
After this PR is merged, create and push tag v0.2.3 to trigger the pub.dev publish workflow.