### PR TITLE
Allow pub.dev publish OIDC token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: read
+      id-token: write
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
       # Specify the github actions deployment environment


### PR DESCRIPTION
Summary:
- Grant the publish reusable workflow the OIDC token permission required for pub.dev trusted publishing.
- Keep the permission scope minimal with contents: read and id-token: write.

Context:
- The v0.2.3 tag triggered the publish workflow, but GitHub reported startup_failure before creating any job.
- This patch lets the reusable dart-lang publish workflow request the pub.dev OIDC token.

Validation:
- git diff --check