### PR TITLE
Allow Dart 3 package consumers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,32 @@ on:
 
 jobs:
   test:
+    name: Test (${{ matrix.flutter.label }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        flutter:
+          - label: Flutter 3.7.12
+            version: "3.7.12"
+          - label: Flutter stable
+            version: ""
 
     steps:
       - uses: actions/checkout@v6
 
-      - uses: subosito/flutter-action@v2
+      - name: Set up Flutter ${{ matrix.flutter.version }}
+        if: matrix.flutter.version != ''
+        uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.7.12"
+          flutter-version: ${{ matrix.flutter.version }}
+          channel: stable
+          cache: true
+
+      - name: Set up latest stable Flutter
+        if: matrix.flutter.version == ''
+        uses: subosito/flutter-action@v2
+        with:
           channel: stable
           cache: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.2.4-dev.1
+
+* Expand Dart SDK compatibility to allow Dart 3.
+* Add CI coverage for both Flutter 3.7.12 and the latest stable Flutter.
+* Avoid deprecated color opacity APIs on current Flutter.
+
 ## 0.2.3
 
 * Add runtime validation for custom gradient and layer configuration.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   flutter:

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -311,7 +311,8 @@ class _WaveWidgetState extends State<WaveWidget> with TickerProviderStateMixin {
       return List<_WaveLayerSpec>.generate(
         singleConfig.durations.length,
         (index) => _WaveLayerSpec(
-          color: singleConfig.color.withOpacity(
+          color: _colorWithOpacity(
+            singleConfig.color,
             singleConfig.opacityPercentages[index],
           ),
           duration: singleConfig.durations[index],
@@ -324,6 +325,10 @@ class _WaveWidgetState extends State<WaveWidget> with TickerProviderStateMixin {
     }
 
     throw FlutterError('Unsupported or missing `ColorMode` in `config`.');
+  }
+
+  Color _colorWithOpacity(Color color, double opacity) {
+    return color.withAlpha((opacity * 255).round());
   }
 
   double _amplitudeForLayer(int index) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: wave
 description: Widget for displaying waves with custom color, duration, floating and blur effects.
-version: 0.2.3
+version: 0.2.4-dev.1
 homepage: https://github.com/glorylab/wave
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Summary:
- Expand the package and example SDK constraints to allow Dart 3 while preserving the Dart 2.12 lower bound.
- Move master development to 0.2.4-dev.1 after the 0.2.3 release.
- Run CI against both Flutter 3.7.12 and the latest stable Flutter.

Validation:
- fvm flutter analyze
- fvm flutter test
- fvm flutter pub publish --dry-run (0 warnings)

Notes:
- The Cloudflare demo deploy remains pinned to Flutter 3.7.12 for now; this PR only changes package compatibility coverage.